### PR TITLE
Add live MuJoCo viewer for deployment

### DIFF
--- a/lsy_drone_racing/utils/deploy_viewer.py
+++ b/lsy_drone_racing/utils/deploy_viewer.py
@@ -1,0 +1,71 @@
+"""Live visualization for real-world deployments."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from lsy_drone_racing.envs.race_core import RaceCoreEnv
+
+
+class DeployViewer:
+    """Mirror the measured race state in a single-world CPU simulation."""
+
+    def __init__(self, env: RaceCoreEnv):
+        """Take ownership of a render-only core environment.
+
+        Args:
+            env: Single-world, single-drone CPU environment used for rendering.
+        """
+        self._env = env
+
+    def warm_up(self):
+        """Compile rendering and open the window before the real drone is armed."""
+        data = self._env.data
+        sim_data = self._env.sim.data.replace(
+            core=self._env.sim.data.core.replace(
+                mjx_synced=self._env.sim.data.core.mjx_synced.at[...].set(False)
+            )
+        )
+        self._env.data = data.replace(sim_data=sim_data)
+        self._env.render()
+
+    def set_track(self, gates_pos: NDArray, gates_quat: NDArray, obstacles_pos: NDArray):
+        """Update the simulation with the measured track poses.
+
+        Args:
+            gates_pos: Gate positions of shape (n_gates, 3).
+            gates_quat: Gate quaternions in SciPy xyzw order with shape (n_gates, 4).
+            obstacles_pos: Obstacle positions of shape (n_obstacles, 3).
+        """
+        data = self._env.data
+        self._env.data = data.replace(
+            gates_pos=data.gates_pos.at[0].set(gates_pos),
+            gates_quat=data.gates_quat.at[0].set(gates_quat),
+            obstacles_pos=data.obstacles_pos.at[0].set(obstacles_pos),
+        )
+
+    def update(self, pos: NDArray, quat: NDArray):
+        """Update the measured drone pose and render it.
+
+        Args:
+            pos: Drone position of shape (3,).
+            quat: Drone quaternion in SciPy xyzw order with shape (4,).
+        """
+        data = self._env.data
+        sim_data = data.sim_data
+        states = sim_data.states.replace(
+            pos=sim_data.states.pos.at[0, 0].set(pos), quat=sim_data.states.quat.at[0, 0].set(quat)
+        )
+        sim_data = sim_data.replace(
+            states=states,
+            core=sim_data.core.replace(mjx_synced=sim_data.core.mjx_synced.at[...].set(False)),
+        )
+        self._env.data = data.replace(sim_data=sim_data)
+        self._env.render()
+
+    def close(self):
+        """Close the simulation and its viewer window."""
+        self._env.close()

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -54,7 +54,7 @@ def main(config: str = "level2.toml", controller: str | None = None, render: boo
     try:
         if render:
             viewer_sim_config = config.sim.copy_and_resolve_references()
-            viewer_sim_config.drone_model = config.deploy.drones[0]["drone_model"]
+            viewer_sim_config.drone = config.deploy.drones[0]["drone"]
             viewer_sim_config.camera = -1
             viewer_env = RaceCoreEnv(
                 n_envs=1,
@@ -73,7 +73,7 @@ def main(config: str = "level2.toml", controller: str | None = None, render: boo
         obs, info = env.reset(seed=config.env.seed, options=config.deploy)
         next_obs = obs  # Set next_obs to avoid errors when the loop never enters
 
-        if viewer is not None:
+        if render:
             viewer.set_track(
                 gates_pos=env.unwrapped.gates.pos,
                 gates_quat=env.unwrapped.gates.quat,
@@ -92,7 +92,7 @@ def main(config: str = "level2.toml", controller: str | None = None, render: boo
             obs = {k: v[0] for k, v in obs.items()}
             action = controller.compute_control(obs, info)
             next_obs, reward, terminated, truncated, info = env.step(action)
-            if viewer is not None:
+            if render:
                 viewer.update(next_obs["pos"], next_obs["quat"])
             controller_finished = controller.step_callback(
                 action, next_obs, reward, terminated, truncated, info

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -17,7 +17,9 @@ import fire
 import gymnasium
 import rclpy
 
+from lsy_drone_racing.envs.race_core import RaceCoreEnv
 from lsy_drone_racing.utils import load_config, load_controller
+from lsy_drone_racing.utils.deploy_viewer import DeployViewer
 
 if TYPE_CHECKING:
     from lsy_drone_racing.envs.real_race_env import RealDroneRaceEnv
@@ -25,13 +27,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def main(config: str = "level2.toml", controller: str | None = None):
+def main(config: str = "level2.toml", controller: str | None = None, render: bool = False):
     """Deployment script to run the controller on the real drone.
 
     Args:
         config: Path to the competition configuration. Assumes the file is in `config/`.
         controller: The name of the controller file in `lsy_drone_racing/control/` or None. If None,
          the controller specified in the config file is used.
+        render: Show a live MuJoCo window that mirrors the real race from mocap data.
     """
     rclpy.init()
     config = load_config(Path(__file__).parents[1] / "config" / config)
@@ -47,9 +50,36 @@ def main(config: str = "level2.toml", controller: str | None = None):
         sensor_range=config.env.sensor_range,
         control_mode=config.env.control_mode,
     )
+    viewer = None
     try:
+        if render:
+            viewer_sim_config = config.sim.copy_and_resolve_references()
+            viewer_sim_config.drone_model = config.deploy.drones[0]["drone_model"]
+            viewer_sim_config.camera = -1
+            viewer_env = RaceCoreEnv(
+                n_envs=1,
+                n_drones=1,
+                freq=config.env.freq,
+                sim_config=viewer_sim_config,
+                sensor_range=config.env.sensor_range,
+                track=config.env.track,
+                control_mode=config.env.control_mode,
+                seed=config.env.seed,
+                device="cpu",
+            )
+            viewer = DeployViewer(viewer_env)
+            viewer.warm_up()
+
         obs, info = env.reset(seed=config.env.seed, options=config.deploy)
         next_obs = obs  # Set next_obs to avoid errors when the loop never enters
+
+        if viewer is not None:
+            viewer.set_track(
+                gates_pos=env.unwrapped.gates.pos,
+                gates_quat=env.unwrapped.gates.quat,
+                obstacles_pos=env.unwrapped.obstacles.pos,
+            )
+            viewer.update(obs["pos"], obs["quat"])
 
         control_path = Path(__file__).parents[1] / "lsy_drone_racing/control"
         controller_path = control_path / config.controller.file
@@ -62,6 +92,8 @@ def main(config: str = "level2.toml", controller: str | None = None):
             obs = {k: v[0] for k, v in obs.items()}
             action = controller.compute_control(obs, info)
             next_obs, reward, terminated, truncated, info = env.step(action)
+            if viewer is not None:
+                viewer.update(next_obs["pos"], next_obs["quat"])
             controller_finished = controller.step_callback(
                 action, next_obs, reward, terminated, truncated, info
             )
@@ -76,6 +108,8 @@ def main(config: str = "level2.toml", controller: str | None = None):
         finished_track = next_obs["n_gates_passed"] == next_obs["gate_sequence"].shape[0]
         logger.info(f"Track time: {ep_time:.3f}s" if finished_track else "Task not completed")
     finally:
+        if viewer is not None:
+            viewer.close()
         env.close()
 
 


### PR DESCRIPTION
when using a `--render` or `-r` arg, a viewer window will open when the deployment starts. Tested in real with level3 state controller and attitude controller. One thing need to notice is that `ctrl+C` can not do emergency stop when focusing on the viewer window.