### PR TITLE
Fix parameter loading

### DIFF
--- a/lsy_drone_racing/control/attitude_controller.py
+++ b/lsy_drone_racing/control/attitude_controller.py
@@ -14,8 +14,7 @@ import math
 from typing import TYPE_CHECKING
 
 import numpy as np
-from crazyflow.dynamics import available_dynamics
-from crazyflow.dynamics.core import load_params
+from crazyflow.drones import load_params as load_hardware_params
 from scipy.interpolate import CubicSpline
 from scipy.spatial.transform import Rotation as R
 
@@ -41,7 +40,7 @@ class AttitudeController(Controller):
         self._freq = config.env.freq
 
         # For more info on the models, check out https://github.com/learnsyslab/crazyflow
-        drone_params = load_params(available_dynamics[config.sim.dynamics], config.sim.drone)
+        drone_params = load_hardware_params(config.sim.drone)
         self.drone_mass = drone_params["mass"]
 
         self.kp = np.array([0.4, 0.4, 1.25])

--- a/lsy_drone_racing/control/attitude_input.py
+++ b/lsy_drone_racing/control/attitude_input.py
@@ -11,10 +11,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pygame
-from crazyflow.control.core import load_params as load_control_params
-from crazyflow.control.mellinger import force_torque2rotor_vel
-from crazyflow.dynamics import available_dynamics
-from crazyflow.dynamics.core import load_params
+from crazyflow.drones import load_params as load_hardware_params
 from scipy.spatial.transform import Rotation as R
 
 from lsy_drone_racing.control import Controller
@@ -39,11 +36,10 @@ class AttitudeController(Controller):
         self.freq = config.env.freq
 
         # For more info on the models, check out https://github.com/learnsyslab/crazyflow
-        drone_params = load_params(available_dynamics[config.sim.dynamics], config.sim.drone)
-        thrust_params = load_control_params(force_torque2rotor_vel, config.sim.drone)
+        drone_params = load_hardware_params(config.sim.drone)
         self.drone_mass = drone_params["mass"]
-        self.thrust_min = thrust_params["thrust_min"] * 4
-        self.thrust_max = thrust_params["thrust_max"] * 4
+        self.thrust_min = drone_params["thrust_min"] * 4
+        self.thrust_max = drone_params["thrust_max"] * 4
 
         self.kp = np.array([0.4, 0.4, 1.25])
         self.ki = np.array([0.05, 0.05, 0.05])

--- a/lsy_drone_racing/control/attitude_mpc.py
+++ b/lsy_drone_racing/control/attitude_mpc.py
@@ -14,9 +14,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 import scipy
 from acados_template import AcadosModel, AcadosOcp, AcadosOcpSolver
-from crazyflow.control.core import load_params as load_control_params
-from crazyflow.control.mellinger import force_torque2rotor_vel
-from crazyflow.dynamics.core import load_params
+from crazyflow.drones import load_params as load_hardware_params
+from crazyflow.dynamics.core import load_params as load_dynamics_params
 from crazyflow.dynamics.so_rpy import dynamics, symbolic_dynamics_euler
 from crazyflow.dynamics.utils.rotation import ang_vel2rpy_rates
 from scipy.interpolate import CubicSpline
@@ -211,8 +210,8 @@ class AttitudeMPC(Controller):
         )
         self._waypoints_yaw = self._waypoints_pos[:, 0] * 0
 
-        self.drone_params = load_params(dynamics, config.sim.drone)
-        thrust_params = load_control_params(force_torque2rotor_vel, config.sim.drone)
+        self.drone_params = load_dynamics_params(dynamics, config.sim.drone)
+        thrust_params = load_hardware_params(config.sim.drone)
         self.drone_params["thrust_min"] = 4 * thrust_params["thrust_min"]
         self.drone_params["thrust_max"] = 4 * thrust_params["thrust_max"]
         self._acados_ocp_solver, self._ocp = create_ocp_solver(

--- a/lsy_drone_racing/control/attitude_rl.py
+++ b/lsy_drone_racing/control/attitude_rl.py
@@ -15,10 +15,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import torch
-from crazyflow.control.core import load_params as load_control_params
-from crazyflow.control.mellinger import force_torque2rotor_vel
-from crazyflow.dynamics import available_dynamics
-from crazyflow.dynamics.core import load_params
+from crazyflow.drones import load_params as load_hardware_params
 from scipy.interpolate import CubicSpline
 
 from lsy_drone_racing.control import Controller
@@ -44,11 +41,10 @@ class AttitudeRL(Controller):
         self.freq = config.env.freq
 
         # For more info on the models, check out https://github.com/learnsyslab/crazyflow
-        drone_params = load_params(available_dynamics[config.sim.dynamics], config.sim.drone)
-        thrust_params = load_control_params(force_torque2rotor_vel, config.sim.drone)
+        drone_params = load_hardware_params(config.sim.drone)
         self.drone_mass = drone_params["mass"]
-        self.thrust_min = thrust_params["thrust_min"] * 4  # min total thrust
-        self.thrust_max = thrust_params["thrust_max"] * 4  # max total thrust
+        self.thrust_min = drone_params["thrust_min"] * 4  # min total thrust
+        self.thrust_max = drone_params["thrust_max"] * 4  # max total thrust
 
         # Set num of stacked obs
         self.n_obs = 2

--- a/lsy_drone_racing/envs/race_core.py
+++ b/lsy_drone_racing/envs/race_core.py
@@ -31,8 +31,7 @@ import jax
 import jax.numpy as jp
 import mujoco
 import numpy as np
-from crazyflow.control.core import load_params
-from crazyflow.control.mellinger import force_torque2rotor_vel
+from crazyflow.drones import load_params as load_hardware_params
 from crazyflow.sim import Sim
 from crazyflow.sim.pipeline import append_fn, insert_fn_before
 from crazyflow.sim.sim import seed_sim, sync_sim2mjx, use_box_collision
@@ -236,7 +235,7 @@ def build_action_space(control_mode: Literal["state", "attitude"], drone: str) -
     if control_mode == "state":
         return spaces.Box(low=-np.inf, high=np.inf, shape=(13,))
     if control_mode == "attitude":
-        params = load_params(force_torque2rotor_vel, drone)
+        params = load_hardware_params(drone)
         thrust_min, thrust_max = params["thrust_min"] * 4, params["thrust_max"] * 4
         return spaces.Box(
             np.array([-np.pi / 2, -np.pi / 2, -np.pi / 2, thrust_min], dtype=np.float32),

--- a/lsy_drone_racing/envs/real_race_env.py
+++ b/lsy_drone_racing/envs/real_race_env.py
@@ -15,8 +15,7 @@ from typing import TYPE_CHECKING, Literal
 import jax
 import numpy as np
 import rclpy
-from crazyflow.dynamics import available_dynamics
-from crazyflow.dynamics.core import load_params
+from crazyflow.drones import load_params as load_hardware_params
 from drone_estimators.ros_nodes.ros2_connector import ROSConnector
 from gymnasium import Env
 from scipy.spatial.transform import Rotation as R
@@ -111,9 +110,7 @@ class RealRaceCoreEnv:
         self.control_mode = control_mode
         self.randomizations = randomizations
         drone_config = drones[rank]
-        self.drone_parameters = load_params(
-            available_dynamics["first_principles"], drone_config["drone"]
-        )
+        self.drone_parameters = load_hardware_params(drone_config["drone"])
         self.drone = Crazyflie.from_radio(
             radio_id=self.rank,
             radio_channel=drone_config["channel"],

--- a/tests/deploy/test_deployment.py
+++ b/tests/deploy/test_deployment.py
@@ -14,8 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from crazyflow.dynamics import available_dynamics
-from crazyflow.dynamics.core import load_params
+from crazyflow.drones import load_params as load_hardware_params
 
 from lsy_drone_racing.control.attitude_controller import AttitudeController
 from lsy_drone_racing.utils import load_config
@@ -198,7 +197,7 @@ def main() -> None:
     drone_name = f"cf{drone_config['id']}"
     radio_id = args.rank if args.radio_id is None else args.radio_id
     home_pos = np.array(config.env.track.drones[args.rank]["pos"], dtype=np.float32)
-    drone_params = load_params(available_dynamics[config.sim.dynamics], drone_config["drone"])
+    drone_params = load_hardware_params(drone_config["drone"])
 
     logger.info("Initializing ROS for %s.", drone_name)
     rclpy.init()


### PR DESCRIPTION
previously, we use a dynamic param loader to load the drone params (e.g. mass, thrust), additionally specify a dynamic function. And maybe the crazyflow upgrade introduced the masking (not sure), the way we load params does not work. 

In this PR, we use the param loader from `crazyflow.drones` to load hardware params, and use` crazyflow.dynamics.core` to load dynamics related params e.g. some coefficients.

tested in real by running `tests/deploy/test_deployment.py`