### PR TITLE
Pixi run mocap runs now also nominal_frame_publisher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ scripts = ["tools/setup_mocap.sh"]
 
 ## feature [deploy]
 [tool.pixi.feature.deploy.tasks]
-mocap = { cmd = "ros2 launch motion_capture_tracking launch.py", description = "Launch the motion capture tracking node" }
+mocap = { cmd = "bash tools/launch_mocap.sh", description = "Launch mocap tracking, nominal frame publisher, and RViz" }
 estimator = { cmd = "python -m drone_estimators.ros_nodes.ros2_node --drone_name {{ drone_name }}", args = [
   { arg = "drone_name" },
 ], description = "Start the drone state estimator" }

--- a/tools/launch_mocap.sh
+++ b/tools/launch_mocap.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+. ./tools/setup_mocap.sh
+
+export ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST
+
+python scripts/nominal_frame_publisher.py &
+publisher_pid=$!
+
+ros2 run motion_capture_tracking motion_capture_tracking_node \
+  --ros-args \
+  --params-file ros_ws/src/motion_capture_tracking/motion_capture_tracking/config/cfg.yaml &
+tracking_pid=$!
+
+cleanup() {
+  kill "$publisher_pid" "$tracking_pid" 2>/dev/null || true
+}
+
+trap cleanup EXIT INT TERM
+
+rviz2 -d tools/mocap.rviz

--- a/tools/mocap.rviz
+++ b/tools/mocap.rviz
@@ -1,0 +1,228 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 138
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /TF1
+        - /MarkerArray1
+      Splitter Ratio: 0.5
+    Tree Height: 563
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Filter (blacklist): ""
+      Filter (whitelist): ""
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        cf100:
+          Value: true
+        cf12:
+          Value: true
+        cf13:
+          Value: true
+        cf14:
+          Value: true
+        cf15:
+          Value: true
+        cf21:
+          Value: true
+        cf25:
+          Value: true
+        drone_init_1:
+          Value: true
+        g1_pelvis:
+          Value: true
+        g_1:
+          Value: true
+        g_2:
+          Value: true
+        g_3:
+          Value: true
+        g_4:
+          Value: true
+        o_1:
+          Value: true
+        o_2:
+          Value: true
+        o_3:
+          Value: true
+        o_4:
+          Value: true
+        world:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        world:
+          cf100:
+            {}
+          cf12:
+            {}
+          cf13:
+            {}
+          cf14:
+            {}
+          cf15:
+            {}
+          cf21:
+            {}
+          cf25:
+            {}
+          drone_init_1:
+            {}
+          g1_pelvis:
+            {}
+          g_1:
+            {}
+          g_2:
+            {}
+          g_3:
+            {}
+          g_4:
+            {}
+          o_1:
+            {}
+          o_2:
+            {}
+          o_3:
+            {}
+          o_4:
+            {}
+      Update Interval: 0
+      Value: true
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: MarkerArray
+      Namespaces:
+        drone_init: true
+        gates: true
+        obstacles: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /nominal_frame_publisher
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: world
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 12.39822769165039
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.5303983688354492
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.07039815932512283
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001f7000002f8fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000002f8000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000015f000002f8fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b000002f8000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004420000003efc0100000002fb0000000800540069006d00650100000000000004420000000000000000fb0000000800540069006d006501000000000000045000000000000000000000014e000002f800000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 1702
+  Y: 246


### PR DESCRIPTION
For easier handling we can now launch the `nominal_frame_publisher` from `pixi run mocap`. The new bash script launches the frame publisher as a background process in the same terminal instance. 
Further, for not having to select the topic and MarkerArray **manually**, I added my rviz config that is being loaded as well. Cheers. 

PS: The cleaner solution would've been to add the config file to the ros ws directly but since `motion_capture_tracking` is not used exclusively for drone racing I looked for a more convenient way.  