### PR TITLE
Remap mocap node to load Vicon parameters

### DIFF
--- a/tools/launch_mocap.sh
+++ b/tools/launch_mocap.sh
@@ -10,6 +10,7 @@ publisher_pid=$!
 
 ros2 run motion_capture_tracking motion_capture_tracking_node \
   --ros-args \
+  --remap __node:=motion_capture_tracking \
   --params-file ros_ws/src/motion_capture_tracking/motion_capture_tracking/config/cfg.yaml &
 tracking_pid=$!
 


### PR DESCRIPTION
previously the mocap node was created by the launch.py with 
```python
Node(
    ... ,
    name="motion_capture_tracking",
    ...
)
```
the recent pr change the way to create the mocap node by using
```bash
ros2 run motion_capture_tracking motion_capture_tracking_node \
  --ros-args \
  --params-file ros_ws/src/motion_capture_tracking/motion_capture_tracking/config/cfg.yaml &
tracking_pid=$!
```
thus the runtime node will be named as `motion_capture_tracking_node`, mismatch the node name in the yaml file, causing the ip address not correctly loaded, so that only nominal frames can be seen in rviz, no vicon objects.

tested in real world